### PR TITLE
12.0-CURRENT invalid mountpoint

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -2306,7 +2306,7 @@ cdef class ZFSDataset(ZFSObject):
             if libzfs.zfs_is_mounted(self.handle, &mntpt) == 0:
                 return None
 
-            result = mntpt
+            result = str(mntpt)
             free(mntpt)
             return result
 


### PR DESCRIPTION
Dataset were mountpoints are not correctly returned. This change makes a real copy of the mountpoint before freeing the memory.

```
$ uname -a
FreeBSD localhost 12.0-CURRENT FreeBSD 12.0-CURRENT #0  9d22e8cc09d(hardened/current/master): Mon Dec 25 18:47:15 UTC 2017     root@localhost:/usr/obj/usr/src/amd64.amd64/sys/HARDENEDBSD  amd64
```

### Current Result
```
$ python3.6
Python 3.6.3 (default, Dec 19 2017, 18:18:45) 
[GCC 4.2.1 Compatible FreeBSD Clang 5.0.1 (tags/RELEASE_501/final 320880)] on freebsd12
Type "help", "copyright", "credits" or "license" for more information.
>>> import libzfs
>>> libzfs.ZFS().get_dataset('zroot').mountpoint
'ZZZZZZZZ>>> '
```

### Expected Result
```
$ python3.6
Python 3.6.3 (default, Dec 19 2017, 18:18:45) 
[GCC 4.2.1 Compatible FreeBSD Clang 5.0.1 (tags/RELEASE_501/final 320880)] on freebsd12
Type "help", "copyright", "credits" or "license" for more information.
>>> import libzfs
>>> libzfs.ZFS().get_dataset('zroot').mountpoint
'/zroot'
```