### PR TITLE
fix an issue when using an inherited ZFS class

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -375,7 +375,7 @@ cdef class ZFS(object):
             self.handle = NULL
 
     def __dealloc__(self):
-        self.__libzfs_fini()
+        ZFS.__libzfs_fini(self)
 
     def __getstate__(self):
         return [p.__getstate__() for p in self.pools]


### PR DESCRIPTION
I'm inheriting from libzfs.ZFS in a project and found the following issue calling the private method `__libzfs_fini()`:

```
AttributeError: 'ZFS' object has no attribute '__libzfs_fini'                                                                                                                                                                                        
Exception ignored in: 'libzfs.ZFS.__dealloc__'                                                                                                                                                                                                       
AttributeError: 'ZFS' object has no attribute '__libzfs_fini'
```

This change calls allows accessing the private mangled attribute by calling the class method rather than the instance method.