### PR TITLE
recursive renaming of ZFSObjects (snapshots)

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -2166,11 +2166,11 @@ cdef class ZFSObject(object):
             d.refresh()
             return d
 
-    def rename(self, new_name, nounmount=False, forceunmount=False):
+    def rename(self, new_name, nounmount=False, forceunmount=False, recursive=False):
         cdef libzfs.renameflags_t flags
         cdef const char *c_new_name = new_name
 
-        flags.recurse = False
+        flags.recurse = recursive
         flags.nounmount = nounmount
         flags.forceunmount = forceunmount
 


### PR DESCRIPTION
Allows to rename snapshots recursively.

```pycon
Python 3.6.5 (default, Jul  1 2018, 13:09:50)
[GCC 4.2.1 Compatible FreeBSD Clang 6.0.0 (tags/RELEASE_600/final 326565)] on freebsd11
Type "help", "copyright", "credits" or "license" for more information.
>>> import libzfs
>>> zfs = libzfs.ZFS()
>>> zfs.get("data").create("data/test", {})
>>> zfs.get("data").create("data/test/A", {})
>>> zfs.get("data").create("data/test/A/B", {})
>>> zfs.get_dataset("data/test/A").snapshot("data/test/A@one", recursive=True)
>>> zfs.get_snapshot("data/test/A/B@one").clone("data/test/C")
>>> zfs.get_dataset("data/test/C").properties["origin"]
<libzfs.ZFSProperty name 'origin' value 'data/test/A/B@one'>
>>> zfs.get_snapshot("data/test/A@one").rename("data/test/A@two", recursive=True)
>>> zfs.get_dataset("data/test/C").properties["origin"]
<libzfs.ZFSProperty name 'origin' value 'data/test/A/B@two'>
```