### PR TITLE
Imitate zpool clear

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -2178,7 +2178,7 @@ cdef class ZFSPool(object):
     def clear(self):
         cdef NVList policy = NVList()
         cdef int ret
-        policy[zfs.ZPOOL_REWIND_REQUEST] = zfs.ZPOOL_NO_REWIND
+        policy[zfs.ZPOOL_LOAD_REWIND_POLICY] = zfs.ZPOOL_NO_REWIND
 
         with nogil:
             ret = libzfs.zpool_clear(self.handle, NULL, policy.handle)

--- a/pxd/zfs.pxd
+++ b/pxd/zfs.pxd
@@ -97,11 +97,12 @@ cdef extern from "sys/fs/zfs.h" nogil:
     const char* VDEV_TYPE_LOG
     const char* VDEV_TYPE_L2CACHE
 
-    const char* ZPOOL_REWIND_POLICY
-    const char* ZPOOL_REWIND_REQUEST
-    const char* ZPOOL_REWIND_REQUEST_TXG
-    const char* ZPOOL_REWIND_META_THRESH
-    const char* ZPOOL_REWIND_DATA_THRESH
+    # Pool load policy parameter
+    const char* ZPOOL_LOAD_POLICY
+    const char* ZPOOL_LOAD_REWIND_POLICY
+    const char* ZPOOL_LOAD_REQUEST_TXG
+    const char* ZPOOL_LOAD_META_THRESH
+    const char* ZPOOL_LOAD_DATA_THRESH
 
     enum:
         ZIO_TYPES


### PR DESCRIPTION
We were setting a different key ("rewind-request") for rewind policy for clearing errors for a given pool. This commit fixes that issue and copies the behaviour from zpool_main where we use ("load-rewind-policy").