### PR TITLE
Improve deletion of snapshot dependents

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -2969,12 +2969,13 @@ cdef class ZFSDataset(ZFSResource):
             free(mntpt)
             return result
 
-    def destroy_snapshot(self, name):
+    def destroy_snapshot(self, name, defer=True):
         cdef const char *c_name = name
         cdef int ret
+        cdef int defer_deletion = defer
 
         with nogil:
-            ret = libzfs.zfs_destroy_snaps(self.handle, c_name, True)
+            ret = libzfs.zfs_destroy_snaps(self.handle, c_name, defer_deletion)
 
         if ret != 0:
             raise self.root.get_error()

--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -3152,7 +3152,7 @@ cdef class ZFSDataset(ZFSResource):
             raise self.root.get_error()
 
 
-cdef class ZFSSnapshot(ZFSObject):
+cdef class ZFSSnapshot(ZFSResource):
     def __getstate__(self):
         ret = super(ZFSSnapshot, self).__getstate__()
         ret.update({
@@ -3162,6 +3162,10 @@ cdef class ZFSSnapshot(ZFSObject):
             'mountpoint': self.mountpoint
         })
         return ret
+
+    property dependents:
+        def __get__(self):
+            return iter(self.get_dependents(True))
 
     def rollback(self, force=False):
         cdef ZFSDataset parent

--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -3262,10 +3262,13 @@ cdef class ZFSSnapshot(ZFSResource):
         self.root.write_history('zfs release', '-r' if recursive else '', tag, self.name)
 
     def delete(self, recursive=False, defer=False):
+        dependents = list(self.dependents)
         if not recursive:
+            if dependents:
+                raise ZFSException(1, f'Cannot destroy {self.name}: snapshot has dependent clones')
             super(ZFSSnapshot, self).delete(defer=defer)
         else:
-            self.parent.destroy_snapshot(self.snapshot_name)
+            self.parent.destroy_snapshot(self.snapshot_name, defer)
 
         self.root.write_history('zfs destroy', '-r' if recursive else '', self.name)
 


### PR DESCRIPTION
This PR introduces the following changes:
1) Ability to retrieve dependents of a snapshot
2) Properly report that snapshot has dependents if recursive flag is not specified
3) Ability to destroy dependent clones