### PR TITLE
Bug fixes for ZFSUserProperty

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -1508,6 +1508,8 @@ cdef class ZFSUserProperty(ZFSProperty):
                 if ret != 0:
                     raise self.dataset.root.get_error()
 
+                self.values['value'] = value
+
     property rawvalue:
         def __get__(self):
             return self.value
@@ -1537,7 +1539,7 @@ cdef class ZFSUserProperty(ZFSProperty):
 
         for k, v in nvl.items():
             if k == self.name:
-                self.values['value'] = v
+                self.values.update(v)
                 break
         else:
             self.values['value'] = None

--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -1452,6 +1452,8 @@ cdef class ZFSProperty(object):
         cdef int c_recursive = recursive
         cdef zfs.zfs_prop_t prop
 
+        self.refresh()
+
         dsets = [self.dataset]
         if recursive:
             dsets.extend(list(self.dataset.children_recursive))
@@ -1460,7 +1462,7 @@ cdef class ZFSProperty(object):
         for d in dsets:
             dset = <ZFSObject>d
             with nogil:
-                if c_recursive:
+                if c_recursive and prop != zfs.ZPROP_INVAL:
                     IF HAVE_ZFS_PROP_VALID_FOR_TYPE == 3:
                         ret = <int>zfs.zfs_prop_valid_for_type(prop, libzfs.zfs_get_type(dset.handle), 0)
                     ELSE:
@@ -1531,6 +1533,8 @@ cdef class ZFSUserProperty(ZFSProperty):
     def refresh(self):
         cdef ZFSUserProperty userprop
         cdef nvpair.nvlist_t *nvlist
+
+        self.cname = self.name
 
         with nogil:
             nvlist = libzfs.zfs_get_user_props(self.dataset.handle)

--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -1526,6 +1526,22 @@ cdef class ZFSUserProperty(ZFSProperty):
 
             return PropertySource.INHERITED
 
+    def refresh(self):
+        cdef ZFSUserProperty userprop
+        cdef nvpair.nvlist_t *nvlist
+
+        with nogil:
+            nvlist = libzfs.zfs_get_user_props(self.dataset.handle)
+
+        nvl = NVList(<uintptr_t>nvlist)
+
+        for k, v in nvl.items():
+            if k == self.name:
+                self.values['value'] = v
+                break
+        else:
+            self.values['value'] = None
+
 
 cdef class ZFSVdevStats(object):
     cdef readonly ZFSVdev vdev

--- a/pxd/zfs.pxd
+++ b/pxd/zfs.pxd
@@ -209,10 +209,6 @@ cdef extern from "sys/fs/zfs.h" nogil:
     
     extern const char *zfs_userquota_prop_prefixes[ZFS_NUM_USERQUOTA_PROPS]
 
-    enum:
-        ZPROP_CONT = -2
-        ZPROP_INVAL	= -1
-    
     ctypedef enum zprop_source_t:
         ZPROP_SRC_NONE = 0x1
         ZPROP_SRC_DEFAULT = 0x2
@@ -223,7 +219,8 @@ cdef extern from "sys/fs/zfs.h" nogil:
         ZPROP_SRC_ALL = 0x3f
 
     ctypedef enum zfs_prop_t:
-        pass
+        ZPROP_CONT = -2
+        ZPROP_INVAL	= -1
     
     ctypedef enum zprop_errflags_t:
         ZPROP_ERR_NOCLEAR = 0x1


### PR DESCRIPTION
This PR fixes following issues:
1) Overrides refresh method of base class as zfs user properties are not stored similar to zfs dataset properties.
2) Makes sure we don't skip inherit operation on a property for a dataset if it's user defined
3) Fixes a SEGFAULT where we used uninitialized variables