### PR TITLE
Remove stale usage

### DIFF
--- a/pxd/libzfs.pxd
+++ b/pxd/libzfs.pxd
@@ -312,7 +312,6 @@ cdef extern from "libzfs.h" nogil:
     extern char *zpool_vdev_name(libzfs_handle_t *, zpool_handle_t *, nvpair.nvlist_t *,
         int verbose)
     extern int zpool_upgrade(zpool_handle_t *, uint64_t)
-    extern int zpool_get_history(zpool_handle_t *, nvpair.nvlist_t **)
     extern int zpool_history_unpack(char *, uint64_t, uint64_t *,
         nvpair.nvlist_t ***, uint_t *)
     extern void zpool_obj_to_path(zpool_handle_t *, uint64_t, uint64_t, char *,


### PR DESCRIPTION
We don't use zpool_get_history anywhere and upstream has changed function signature. However the build still works as it's not being referenced anywhere yet, it's best to remove it until we actually use it.