### PR TITLE
Add ability to retrieve details of specific datasets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,25 @@ FROM debian:testing
 
 ENV DEBIAN_FRONTEND noninteractive
 
-COPY sources.list /etc/apt/sources.list
-
 RUN apt-get update
 
 RUN apt-get install -y \
       debhelper-compat \
       dh-python \
       cython3 \
-      libzfslinux-dev \
       python3-all-dev \
-      python3-setuptools
+      python3-setuptools \
+      git \
+      devscripts
+
+# We will build openzfs now to get latest changes
+RUN mkdir /zfs-package
+RUN git clone --depth=1 https://github.com/truenas/zfs -b truenas/zfs-2.0-release /zfs-package/zfs
+
+WORKDIR /zfs-package/zfs
+RUN cp -a /zfs-package/zfs/contrib/truenas /zfs-package/zfs/debian
+RUN mk-build-deps --build-dep
+RUN apt install -y ./*.deb
+RUN dch -b -M --force-distribution --distribution bullseye-truenas-unstable 'Tagged from py-libzfs'
+RUN debuild -us -uc -b
+RUN apt-get install -y ../*.deb


### PR DESCRIPTION
This PR adds following changes:

1) Update Dockerfile to build latest openzfs packages ( currently docker builds are broken due to shift in our openzfs packages - this fixes it )
2) `datasets_serialized` is an endpoint in py-libzfs which is considerably faster then getting serialized datasets data from the dataset class.
