### PR TITLE
Bug fix for retrieving error from libzfs

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -467,7 +467,7 @@ cdef class ZFS(object):
     cdef object get_error(self):
         return ZFSException(
             Error(libzfs.libzfs_errno(self.handle)),
-            libzfs.libzfs_error_description(self.handle)
+            (<bytes>libzfs.libzfs_error_description(self.handle)).decode('utf-8', 'backslashreplace')
         )
 
     cdef ZFSVdev make_vdev_tree(self, topology, props=None):


### PR DESCRIPTION
This commit fixes an issue where cython when implicitly trying to convert to string fails because 'decode' is unable to decode certain characters resulting into a decode error.

Failure example:
```
>>> import libzfs;z=libzfs.ZFS();p=z.get('vol1');p.create('data/датасет', {})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "libzfs.pyx", line 2813, in libzfs.ZFSPool.create
  File "libzfs.pyx", line 471, in libzfs.ZFS.get_error
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xd0 in position 19: invalid continuation byte
>>> exit()
```
Working example:
```
>>> import libzfs;z=libzfs.ZFS();p=z.get('vol1');p.create('data/датасет', {})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "libzfs.pyx", line 2803, in libzfs.ZFSPool.create
libzfs.ZFSException: invalid character '\xd0' in name
>>>
```