### PR TITLE
Update Makefile.in

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,4 +1,4 @@
-PYTHON ?= /usr/local/bin/python3.7
+PYTHON ?= python3
 PREFIX ?= /usr/local
 
 PXIS = \


### PR DESCRIPTION
Leave it to the system to find the correct python3 version.

I see no need to support python2 in any way.