### PR TITLE
Do not treat mountpoint specially

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -626,11 +626,6 @@ cdef class ZFS(object):
                 ZFS.__datasets_snapshots(handle, <void*>snap_list)
                 data[name]['snapshots'] = snap_list[1:]
 
-            data[name]['mountpoint'] = None
-            if properties.get('mounted', {}).get('value') == 'yes':
-                if properties.get('mountpoint', {}).get('value') != 'none':
-                    data[name]['mountpoint'] = properties['mountpoint']['value']
-
         libzfs.zfs_close(handle)
 
     def datasets_serialized(


### PR DESCRIPTION
Recently we removed usage(s) of having top level props in e606cd583951e5836da47d7d379a6c523e790f1b. We should remove the only property which is being added to top level in the dict which is mountpoint for 3 reasons

1) First being that right now it's dependent on mounted property which might not be retrieved if not explicitly specified
2) This is internal API, there shouldn't be any motivation to treat this specially
3) If mountpoint property is not explicity set to not be retrieved, it would result in mountpoint coming up as null giving a false impression that it is `None` whereas in reality it was just not retrieved.