### PR TITLE
Only retrieve snapshot names when retrieving with datasets

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -621,7 +621,7 @@ cdef class ZFS(object):
                 data[name]['children'] = list(child_data.values())
 
             if configuration_data['snapshots']:
-                snap_list = ZFS._snapshots_snaplist_arg(None, False, False, False, False)
+                snap_list = ZFS._snapshots_snaplist_arg(['name'], False, False, False, False)
                 snap_list[0]['pool'] = configuration_data['pool']
                 ZFS.__datasets_snapshots(handle, <void*>snap_list)
                 data[name]['snapshots'] = snap_list[1:]
@@ -952,7 +952,6 @@ cdef class ZFS(object):
                 ZFS.__datasets_snapshots(handle, <void*>snap_list)
 
         return snap_list[1:]
-
 
     def snapshots_serialized(self, props=None, holds=False, mounted=False, datasets=None, recursive=True):
         datasets = datasets or [p.name for p in self.pools]


### PR DESCRIPTION
This commit adds changes to only retrieve snapshot names when retrieving datasets as they can potentially take lots of time to retrieve for each dataset with all properties. This is not being consumed internally + publicly right now, so we can alter/change the behavior.