### PR TITLE
Remove logging if we are not able to retrieve dataset handle

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -670,12 +670,9 @@ cdef class ZFS(object):
             with nogil:
                 handle = libzfs.zfs_open(self.handle, c_name, zfs.ZFS_TYPE_FILESYSTEM | zfs.ZFS_TYPE_VOLUME)
                 if handle == NULL:
-                    with gil:
-                        e_args = self.get_error().args
-                        logger.error(
-                            'Failed to retrieve dataset handle for %s: %s', c_name, e_args[0] if e_args else ''
-                        )
-                        continue
+                    # It just means that the dataset in question does not exist
+                    # and it's okay to continue checking the next one
+                    continue
                 else:
                     ZFS.__dataset_handles(handle, <void*>dataset)
 


### PR DESCRIPTION
This commit adds changes to remove logging where if py-libzfs is unable to retrieve dataset handle it logs it was not able to do so as an error however consumers of this endpoing like zfs.dataset just might be safely checking if dataset exists or not which results in false positives being logged that an actual error might have happened.