### PR TITLE
Allow waiting for zfs pool activities

### DIFF
--- a/pxd/libzfs.pxd
+++ b/pxd/libzfs.pxd
@@ -17,7 +17,7 @@ cdef extern from "libzfs_core.h" nogil:
     ELSE:
         extern int lzc_send_space(const char *, const char *, uint64_t *)
 
-    extern int lzc_wait(const char *, zpool_wait_activity_t, boolean_t *)
+    extern int lzc_wait(const char *, zfs.zpool_wait_activity_t, boolean_t *)
 
     enum lzc_send_flags:
             LZC_SEND_FLAG_EMBED_DATA

--- a/pxd/libzfs.pxd
+++ b/pxd/libzfs.pxd
@@ -17,6 +17,8 @@ cdef extern from "libzfs_core.h" nogil:
     ELSE:
         extern int lzc_send_space(const char *, const char *, uint64_t *)
 
+    extern int lzc_wait(const char *, zpool_wait_activity_t, boolean_t *)
+
     enum lzc_send_flags:
             LZC_SEND_FLAG_EMBED_DATA
     IF HAVE_LZC_BOOKMARK:

--- a/pxd/zfs.pxd
+++ b/pxd/zfs.pxd
@@ -97,6 +97,17 @@ cdef extern from "sys/fs/zfs.h" nogil:
             pass
 
     enum:
+        ZPOOL_WAIT_CKPT_DISCARD,
+        ZPOOL_WAIT_FREE,
+        ZPOOL_WAIT_INITIALIZE,
+        ZPOOL_WAIT_REPLACE,
+        ZPOOL_WAIT_REMOVE,
+        ZPOOL_WAIT_RESILVER,
+        ZPOOL_WAIT_SCRUB,
+        ZPOOL_WAIT_TRIM,
+        ZPOOL_WAIT_NUM_ACTIVITIES
+
+    enum:
         ZIO_TYPES
         ZFS_NUM_USERQUOTA_PROPS
         ZFS_NUM_PROPS

--- a/pxd/zfs.pxd
+++ b/pxd/zfs.pxd
@@ -96,7 +96,7 @@ cdef extern from "sys/fs/zfs.h" nogil:
         ctypedef enum zpool_errata_t:
             pass
 
-    enum:
+    ctypedef enum zpool_wait_activity_t:
         ZPOOL_WAIT_CKPT_DISCARD,
         ZPOOL_WAIT_FREE,
         ZPOOL_WAIT_INITIALIZE,


### PR DESCRIPTION
This PR adds changes to allow waiting for zpool activities like removal of top level vdevs.