### PR TITLE
Allow using zfs_prop_set_list for updating dataset properties

### DIFF
--- a/pxd/libzfs.pxd
+++ b/pxd/libzfs.pxd
@@ -152,6 +152,7 @@ cdef extern from "libzfs.h" nogil:
 
     extern libzfs_handle_t *zpool_get_handle(zpool_handle_t *)
     extern libzfs_handle_t *zfs_get_handle(zfs_handle_t *)
+    extern int zfs_prop_set_list(zfs_handle_t *,  nvpair.nvlist_t *);
 
     extern void libzfs_print_on_error(libzfs_handle_t *, int)
 


### PR DESCRIPTION
This PR adds changes to allow using `zfs_prop_set_list` for updating dataset properties. This helps in the followings ways:

1) Any normalization of order of properties for example is done by zfs itself and we don't have to worry about it.
2) It's done in a single call instead of us updating each property separately.