### PR TITLE
Allow deleting snapshots by defining ranges of snapshots for a dataset

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -3360,10 +3360,6 @@ cdef class ZFSDataset(ZFSResource):
             handle = libzfs.zfs_open(self.root.handle, c_name, zfs.ZFS_TYPE_FILESYSTEM)
             ZFSDataset.__gather_snapshots(handle, <void*>snap_config)
 
-        # TODO: Fix error handling here for invalid specs
-        print('\n\nsnap config is -- ')
-        from pprint import pprint as pp
-        pp(snap_config)
         snap_names = NVList(otherdict={k: True for k in snap_config['snapshots']})
         with nogil:
             err = libzfs.zfs_destroy_snaps_nvl(self.root.handle, snap_names.handle, False)

--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -3318,7 +3318,7 @@ cdef class ZFSDataset(ZFSResource):
         libzfs.zfs_close(handle)
 
 
-    def delete_snapshots(self, snapshots_spec):
+    def delete_snapshots(self, snapshots_spec, recursive=False):
         # We expect snapshots_spec to be a dict conforming to following valid formats
         # {"all": false, "snapshots": [snapname1, {"start": snap1, "end": snap2}]}
         cdef const char *c_name
@@ -3351,7 +3351,7 @@ cdef class ZFSDataset(ZFSResource):
 
         c_name = self.name
         snap_config = {
-            'recursive': False,
+            'recursive': recursive,
             'failure': False,
             'snapshots': [],
             'snapshot_specification': snap_filter,


### PR DESCRIPTION
This PR adds changes to expose upstream functionality where we can specify ranges of snapshots which are sorted based on time while deleting them.