### PR TITLE
NAS-114192 / 12.0 / Fix Cython conflict with OpenZFS fallthrough macro

### DIFF
--- a/configure
+++ b/configure
@@ -2989,6 +2989,7 @@ case "${host_os}" in
 		;;
 esac
 
+CFLAGS="-DCYTHON_FALLTHROUGH"
 LIBS="-lzfs -lnvpair -lzfs_core -luutil"
 
 if [ "${build_freebsd}" = "yes" ]; then

--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,7 @@ case "${host_os}" in
 		;;
 esac
 
+CFLAGS="-DCYTHON_FALLTHROUGH"
 LIBS="-lzfs -lnvpair -lzfs_core -luutil"
 
 if [[ "${build_freebsd}" = "yes" ]]; then


### PR DESCRIPTION
openzfs/zfs@6954c22 introduced a fallthrough macro that conflicts with
the definition of CYTHON_FALLTHROUGH.  We aren't checking fallthrough,
so work around the issue by shorting out the CYTHON_FALLTHROUGH
definition.

