### PR TITLE
NAS-114356 / 13.0 / Make sure we close opened snapshot handle (by sonicaj)

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -904,6 +904,8 @@ cdef class ZFS(object):
 
             snap_list.append(snap_data)
 
+        libzfs.zfs_close(handle)
+
     @staticmethod
     cdef int __datasets_snapshots(libzfs.zfs_handle_t *handle, void *arg) nogil:
         cdef boolean_t close_handle, recursive

--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -908,18 +908,20 @@ cdef class ZFS(object):
 
     @staticmethod
     cdef int __datasets_snapshots(libzfs.zfs_handle_t *handle, void *arg) nogil:
-        cdef boolean_t close_handle, recursive
+        cdef boolean_t close_handle, recursive, is_dataset
 
+        is_dataset = libzfs.zfs_get_type(handle) != zfs.ZFS_TYPE_SNAPSHOT
         ZFS.__snapshot_details(handle, arg)
         with gil:
             snap_list = <object> arg
             close_handle = snap_list[0]['close_handle']
             recursive = snap_list[0]['recursive']
 
-        if recursive:
-            libzfs.zfs_iter_filesystems(handle, ZFS.__datasets_snapshots, arg)
-        if close_handle:
-            libzfs.zfs_close(handle)
+        if is_dataset:
+            if recursive:
+                libzfs.zfs_iter_filesystems(handle, ZFS.__datasets_snapshots, arg)
+            if close_handle:
+                libzfs.zfs_close(handle)
 
     @staticmethod
     cdef object _snapshots_snaplist_arg(


### PR DESCRIPTION
This commit adds changes to close snapshot handle as otherwise we continue on leaking memory.

Original PR: https://github.com/truenas/py-libzfs/pull/159
Jira URL: https://jira.ixsystems.com/browse/NAS-114356