### PR TITLE
NAS-114076 / 22.02 / Consider resilvering pool healthy, but add a warning yellow light (by themylogin)

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -2427,6 +2427,7 @@ cdef class ZFSPool(object):
             'hostname': self.hostname,
             'status': self.status,
             'healthy': self.healthy,
+            'warning': self.warning,
             'error_count': self.error_count,
             'root_dataset': root_ds,
             'properties': {k: p.__getstate__() for k, p in self.properties.items()} if self.properties else None,
@@ -2615,18 +2616,25 @@ cdef class ZFSPool(object):
                 ELSE:
                     return PoolStatus(libzfs.zpool_get_status(self.handle, &msg_id))
 
+    def __warning_statuses(self):
+        statuses = [
+            PoolStatus.RESILVERING,
+            PoolStatus.VERSION_OLDER,
+            PoolStatus.FEAT_DISABLED,
+        ]
+
+        IF HAVE_ZPOOL_STATUS_NON_NATIVE_ASHIFT:
+            statuses.append(PoolStatus.NON_NATIVE_ASHIFT)
+
+        return statuses
+
     property healthy:
         def __get__(self):
-            ok = [
-                PoolStatus.OK,
-                PoolStatus.VERSION_OLDER,
-                PoolStatus.FEAT_DISABLED
-            ]
+            return self.status_code in [PoolStatus.OK] + self.__warning_statuses()
 
-            IF HAVE_ZPOOL_STATUS_NON_NATIVE_ASHIFT:
-                ok.append(PoolStatus.NON_NATIVE_ASHIFT)
-
-            return self.status_code in ok
+    property warning:
+        def __get__(self):
+            return self.status_code in self.__warning_statuses()
 
     def __unsup_features(self):
         try:


### PR DESCRIPTION
@rick-mesta my proposal is to stop considering a pool being resilvered as non-healthy, but add `"warning": true` flag for UI to display it as a yellow pool status (in addition to currently present green and red).

Original PR: https://github.com/truenas/py-libzfs/pull/158
Jira URL: https://jira.ixsystems.com/browse/NAS-114076