### PR TITLE
NAS-114510 / Add checks for memory allocations

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -3278,8 +3278,8 @@ cdef class ZFSResource(ZFSObject):
         cdef iter_state iter
         cdef int recursion = allow_recursion
 
-        memset(&iter, 0, sizeof(iter))
         with nogil:
+            memset(&iter, 0, sizeof(iter))
             libzfs.zfs_iter_dependents(self.handle, recursion, self.__iterate, <void*>&iter)
 
         try:
@@ -3450,8 +3450,8 @@ cdef class ZFSDataset(ZFSResource):
             cdef iter_state iter
 
             datasets = []
-            memset(&iter, 0, sizeof(iter))
             with nogil:
+                memset(&iter, 0, sizeof(iter))
                 libzfs.zfs_iter_filesystems(self.handle, self.__iterate, <void*>&iter)
 
             try:
@@ -3476,8 +3476,8 @@ cdef class ZFSDataset(ZFSResource):
             cdef ZFSSnapshot snapshot
             cdef iter_state iter
 
-            memset(&iter, 0, sizeof(iter))
             with nogil:
+                memset(&iter, 0, sizeof(iter))
                 IF HAVE_ZFS_ITER_SNAPSHOTS == 6:
                     libzfs.zfs_iter_snapshots(self.handle, False, self.__iterate, <void*>&iter, 0, 0)
                 ELSE:
@@ -3501,8 +3501,8 @@ cdef class ZFSDataset(ZFSResource):
             cdef ZFSBookmark bookmark
             cdef iter_state iter
 
-            memset(&iter, 0, sizeof(iter))
             with nogil:
+                memset(&iter, 0, sizeof(iter))
                 libzfs.zfs_iter_bookmarks(self.handle, self.__iterate, <void *>&iter)
 
             try:

--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -3278,6 +3278,7 @@ cdef class ZFSResource(ZFSObject):
         cdef iter_state iter
         cdef int recursion = allow_recursion
 
+        memset(&iter, 0, sizeof(iter))
         with nogil:
             libzfs.zfs_iter_dependents(self.handle, recursion, self.__iterate, <void*>&iter)
 
@@ -3449,6 +3450,7 @@ cdef class ZFSDataset(ZFSResource):
             cdef iter_state iter
 
             datasets = []
+            memset(&iter, 0, sizeof(iter))
             with nogil:
                 libzfs.zfs_iter_filesystems(self.handle, self.__iterate, <void*>&iter)
 
@@ -3499,6 +3501,7 @@ cdef class ZFSDataset(ZFSResource):
             cdef ZFSBookmark bookmark
             cdef iter_state iter
 
+            memset(&iter, 0, sizeof(iter))
             with nogil:
                 libzfs.zfs_iter_bookmarks(self.handle, self.__iterate, <void *>&iter)
 

--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -3255,7 +3255,7 @@ cdef class ZFSResource(ZFSObject):
 
     @staticmethod
     cdef int __iterate(libzfs.zfs_handle_t* handle, void *arg) nogil:
-        cdef iter_state *iter, *new
+        cdef iter_state *iter, new
 
         iter = <iter_state *>arg
         if iter.length == iter.alloc:


### PR DESCRIPTION
Raise MemoryError() if malloc() or realloc() fail. Explicitly zero-out private data before passing into iterators.