### PR TITLE
NAS-114510 / 13.0 / Add checks for memory allocations

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -803,7 +803,7 @@ cdef class ZFS(object):
         cdef char cvalue[libzfs.ZFS_MAXPROPLEN + 1]
         cdef zfs.zprop_source_t csource
         cdef const char *name
-        cdef const char *mntpt
+        cdef char *mntpt
         cdef nvpair.nvlist_t *ptr
         cdef nvpair.nvlist_t *nvlist
 
@@ -893,7 +893,13 @@ cdef class ZFS(object):
             ret = libzfs.zfs_is_mounted(handle, &mntpt)
 
             with gil:
-                snap_data['mountpoint'] = mntpt if ret !=0 else None
+                if ret == 0:
+                    snap_data['mountpoint'] = None
+                else:
+                    try:
+                        snap_data['mountpoint'] = str(mntpt)
+                    finally:
+                        free(mntpt)
 
         with gil:
             if not simple_handle:


### PR DESCRIPTION
Raise MemoryError() if malloc() or realloc() fail. Explicitly zero-out private data before passing into iterators.
