### PR TITLE
Simplify get_object()

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -1253,13 +1253,7 @@ cdef class ZFS(object):
         return snap
 
     def get_object(self, name):
-        try:
-            return self.get_dataset(name)
-        except ZFSException as err:
-            if err.code == Error.NOENT:
-                return self.get_snapshot(name)
-
-            raise err
+        return self.get_snapshot(name) if "@" in name else self.get_dataset(name)
 
     def get_dataset_by_path(self, path):
         cdef libzfs.zfs_handle_t* handle


### PR DESCRIPTION
"@" character will only occur in name of snapshot.
C.F. zfs_validate_name()

```
/*
 * Validate a ZFS path.  This is used even before trying to open the dataset, to
 * provide a more meaningful error message.  We call zfs_error_aux() to
 * explain exactly why the name was not valid.
 */
int
zfs_validate_name(libzfs_handle_t *hdl, const char *path, int type,
    boolean_t modifying)
{
        namecheck_err_t why;
        char what;

        if (!(type & ZFS_TYPE_SNAPSHOT) && strchr(path, '@') != NULL) {
                if (hdl != NULL)
                        zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
                            "snapshot delimiter '@' is not expected here"));
                return (0);
        }
```

Hence we can simply check for presence of this character rather than
relying on exception for control flow.