### PR TITLE
NAS-114529 / 22.02 / Fix memory leak in py-libzfs iterators

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -3249,7 +3249,8 @@ cdef class ZFSResource(ZFSObject):
 
     @staticmethod
     cdef int __iterate(libzfs.zfs_handle_t* handle, void *arg) nogil:
-        cdef iter_state *iter, new
+        cdef iter_state *iter
+        cdef iter_state new
 
         iter = <iter_state *>arg
         if iter.length == iter.alloc:
@@ -3304,8 +3305,7 @@ cdef class ZFSResource(ZFSObject):
             with nogil:
                 for h in range(0, iter.length):
                     if iter.array[h]:
-                        with nogil:
-                            libzfs.zfs_close(<libzfs.zfs_handle_t*>iter.array[h])
+                        libzfs.zfs_close(<libzfs.zfs_handle_t*>iter.array[h])
 
                 free(iter.array)
 

--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -3275,6 +3275,9 @@ cdef class ZFSResource(ZFSObject):
         with nogil:
             iter.length = 0
             iter.array = <uintptr_t *>malloc(128 * sizeof(uintptr_t))
+            if not iter.array:
+                raise MemoryError()
+
             iter.alloc = 128
             libzfs.zfs_iter_dependents(self.handle, recursion, self.__iterate, <void*>&iter)
 
@@ -3298,12 +3301,13 @@ cdef class ZFSResource(ZFSObject):
                     snapshot.pool = self.pool
                     yield snapshot
         finally:
-            for h in range(0, iter.length):
-                if iter.array[h]:
-                    with nogil:
-                        libzfs.zfs_close(<libzfs.zfs_handle_t*>iter.array[h])
+            with nogil:
+                for h in range(0, iter.length):
+                    if iter.array[h]:
+                        with nogil:
+                            libzfs.zfs_close(<libzfs.zfs_handle_t*>iter.array[h])
 
-            free(iter.array)
+                free(iter.array)
 
     def update_properties(self, all_properties):
         cdef NVList props = NVList()
@@ -3456,6 +3460,9 @@ cdef class ZFSDataset(ZFSResource):
             with nogil:
                 iter.length = 0
                 iter.array = <uintptr_t *>malloc(128 * sizeof(uintptr_t))
+                if not iter.array:
+                    raise MemoryError()
+
                 iter.alloc = 128
                 libzfs.zfs_iter_filesystems(self.handle, self.__iterate, <void*>&iter)
 
@@ -3468,12 +3475,12 @@ cdef class ZFSDataset(ZFSResource):
                     dataset.pool = self.pool
                     yield dataset
             finally:
-                for h in range(0, iter.length):
-                    if iter.array[h]:
-                        with nogil:
+                with nogil:
+                    for h in range(0, iter.length):
+                        if iter.array[h]:
                             libzfs.zfs_close(<libzfs.zfs_handle_t*>iter.array[h])
 
-                free(iter.array)
+                    free(iter.array)
 
     property children_recursive:
         def __get__(self):
@@ -3490,6 +3497,9 @@ cdef class ZFSDataset(ZFSResource):
             with nogil:
                 iter.length = 0
                 iter.array = <uintptr_t *>malloc(128 * sizeof(uintptr_t))
+                if not iter.array:
+                    raise MemoryError()
+
                 iter.alloc = 128
                 IF HAVE_ZFS_ITER_SNAPSHOTS == 6:
                     libzfs.zfs_iter_snapshots(self.handle, False, self.__iterate, <void*>&iter, 0, 0)
@@ -3508,9 +3518,9 @@ cdef class ZFSDataset(ZFSResource):
 
                     yield snapshot
             finally:
-                for h in range(0, iter.length):
-                    if iter.array[h]:
-                        with nogil:
+                with nogil:
+                    for h in range(0, iter.length):
+                        if iter.array[h]:
                             libzfs.zfs_close(<libzfs.zfs_handle_t*>iter.array[h])
 
                 free(iter.array)
@@ -3523,6 +3533,9 @@ cdef class ZFSDataset(ZFSResource):
             with nogil:
                 iter.length = 0
                 iter.array = <uintptr_t *>malloc(128 * sizeof(uintptr_t))
+                if not iter.array:
+                    raise MemoryError()
+
                 iter.alloc = 128
                 libzfs.zfs_iter_bookmarks(self.handle, self.__iterate, <void *>&iter)
 
@@ -3535,12 +3548,12 @@ cdef class ZFSDataset(ZFSResource):
                     bookmark.pool = self.pool
                     yield bookmark
             finally:
-                for h in range(0, iter.length):
-                    if iter.array[h]:
-                        with nogil:
+                with nogil:
+                    for h in range(0, iter.length):
+                        if iter.array[h]:
                             libzfs.zfs_close(<libzfs.zfs_handle_t*>iter.array[h])
 
-                free(iter.array)
+                    free(iter.array)
 
     property snapshots_recursive:
         def __get__(self):

--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -3523,7 +3523,7 @@ cdef class ZFSDataset(ZFSResource):
                         if iter.array[h]:
                             libzfs.zfs_close(<libzfs.zfs_handle_t*>iter.array[h])
 
-                free(iter.array)
+                    free(iter.array)
 
     property bookmarks:
         def __get__(self):

--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -3273,7 +3273,9 @@ cdef class ZFSResource(ZFSObject):
         cdef int recursion = allow_recursion
 
         with nogil:
-            memset(&iter, 0, sizeof(iter))
+            iter.length = 0
+            iter.array = <uintptr_t *>malloc(128 * sizeof(uintptr_t))
+            iter.alloc = 128
             libzfs.zfs_iter_dependents(self.handle, recursion, self.__iterate, <void*>&iter)
 
         try:
@@ -3282,18 +3284,25 @@ cdef class ZFSResource(ZFSObject):
 
                 if type == zfs.ZFS_TYPE_FILESYSTEM or type == zfs.ZFS_TYPE_VOLUME:
                     dataset = ZFSDataset.__new__(ZFSDataset)
+                    dataset.handle = <libzfs.zfs_handle_t*>iter.array[h]
+                    iter.array[h] = 0
                     dataset.root = self.root
                     dataset.pool = self.pool
-                    dataset.handle = <libzfs.zfs_handle_t*>iter.array[h]
                     yield dataset
 
                 if type == zfs.ZFS_TYPE_SNAPSHOT:
                     snapshot = ZFSSnapshot.__new__(ZFSSnapshot)
+                    snapshot.handle = <libzfs.zfs_handle_t*>iter.array[h]
+                    iter.array[h] = 0
                     snapshot.root = self.root
                     snapshot.pool = self.pool
-                    snapshot.handle = <libzfs.zfs_handle_t*>iter.array[h]
                     yield snapshot
         finally:
+            for h in range(0, iter.length):
+                if iter.array[h]:
+                    with nogil:
+                        libzfs.zfs_close(<libzfs.zfs_handle_t*>iter.array[h])
+
             free(iter.array)
 
     def update_properties(self, all_properties):
@@ -3445,17 +3454,25 @@ cdef class ZFSDataset(ZFSResource):
 
             datasets = []
             with nogil:
-                memset(&iter, 0, sizeof(iter))
+                iter.length = 0
+                iter.array = <uintptr_t *>malloc(128 * sizeof(uintptr_t))
+                iter.alloc = 128
                 libzfs.zfs_iter_filesystems(self.handle, self.__iterate, <void*>&iter)
 
             try:
                 for h in range(0, iter.length):
                     dataset = ZFSDataset.__new__(ZFSDataset)
+                    dataset.handle = <libzfs.zfs_handle_t*>iter.array[h]
+                    iter.array[h] = 0
                     dataset.root = self.root
                     dataset.pool = self.pool
-                    dataset.handle = <libzfs.zfs_handle_t*>iter.array[h]
                     yield dataset
             finally:
+                for h in range(0, iter.length):
+                    if iter.array[h]:
+                        with nogil:
+                            libzfs.zfs_close(<libzfs.zfs_handle_t*>iter.array[h])
+
                 free(iter.array)
 
     property children_recursive:
@@ -3471,7 +3488,9 @@ cdef class ZFSDataset(ZFSResource):
             cdef iter_state iter
 
             with nogil:
-                memset(&iter, 0, sizeof(iter))
+                iter.length = 0
+                iter.array = <uintptr_t *>malloc(128 * sizeof(uintptr_t))
+                iter.alloc = 128
                 IF HAVE_ZFS_ITER_SNAPSHOTS == 6:
                     libzfs.zfs_iter_snapshots(self.handle, False, self.__iterate, <void*>&iter, 0, 0)
                 ELSE:
@@ -3480,14 +3499,20 @@ cdef class ZFSDataset(ZFSResource):
             try:
                 for h in range(0, iter.length):
                     snapshot = ZFSSnapshot.__new__(ZFSSnapshot)
+                    snapshot.handle = <libzfs.zfs_handle_t*>iter.array[h]
+                    iter.array[h] = 0
                     snapshot.root = self.root
                     snapshot.pool = self.pool
-                    snapshot.handle = <libzfs.zfs_handle_t*>iter.array[h]
                     if snapshot.snapshot_name == '$ORIGIN':
                         continue
 
                     yield snapshot
             finally:
+                for h in range(0, iter.length):
+                    if iter.array[h]:
+                        with nogil:
+                            libzfs.zfs_close(<libzfs.zfs_handle_t*>iter.array[h])
+
                 free(iter.array)
 
     property bookmarks:
@@ -3496,17 +3521,25 @@ cdef class ZFSDataset(ZFSResource):
             cdef iter_state iter
 
             with nogil:
-                memset(&iter, 0, sizeof(iter))
+                iter.length = 0
+                iter.array = <uintptr_t *>malloc(128 * sizeof(uintptr_t))
+                iter.alloc = 128
                 libzfs.zfs_iter_bookmarks(self.handle, self.__iterate, <void *>&iter)
 
             try:
                 for b in range(0, iter.length):
                     bookmark = ZFSBookmark.__new__(ZFSBookmark)
+                    bookmark.handle = <libzfs.zfs_handle_t*>iter.array[b]
+                    iter.array[b] = 0
                     bookmark.root = self.root
                     bookmark.pool = self.pool
-                    bookmark.handle = <libzfs.zfs_handle_t*>iter.array[b]
                     yield bookmark
             finally:
+                for h in range(0, iter.length):
+                    if iter.array[h]:
+                        with nogil:
+                            libzfs.zfs_close(<libzfs.zfs_handle_t*>iter.array[h])
+
                 free(iter.array)
 
     property snapshots_recursive:


### PR DESCRIPTION
When using generator to iteratate filesystems, snapshots, etc,
any instance where we stop without completely iterating the
array of returned ZFS dataset handles would results in leaking
handles (because no ZFSObject was created / given ownership of them).

This PR explicitly sets the zeroes out array as we grab zhandles
from it when generating ZFSObjects, then performs cleanup when
we are done by closing any zhandles that weren't used.

This PR also adds an explicit malloc / initialization of the
iter info at the beginning of the generator. Although possibly
not strictly necessary, it helps make the code more easily
verifiable that memory is being allocated / freed properly.