### PR TITLE
NAS-113469 / 22.12 / Return ZFS vdev name

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -2034,6 +2034,7 @@ cdef class ZFSVdev(object):
 
     def __getstate__(self, recursive=True):
         ret = {
+            'name': self.name,
             'type': self.type,
             'path': self.path,
             'guid': str(self.guid),
@@ -2254,6 +2255,19 @@ cdef class ZFSVdev(object):
     property guid:
         def __get__(self):
             return self.nvlist.get(zfs.ZPOOL_CONFIG_GUID)
+
+    property name:
+        def __get__(self):
+            cdef char *mntpt
+            mntpt = libzfs.zpool_vdev_name(
+                <libzfs.libzfs_handle_t *>self.root,
+                <libzfs.zpool_handle_t *>self.zpool.handle,
+                self.nvlist.handle,
+                libzfs.VDEV_NAME_TYPE_ID)
+            try:
+                return str(mntpt)
+            finally:
+                free(mntpt)
 
     property path:
         def __get__(self):

--- a/pxd/libzfs.pxd
+++ b/pxd/libzfs.pxd
@@ -222,6 +222,12 @@ cdef extern from "libzfs.h" nogil:
     extern const char *zpool_prop_to_name(int prop)
     extern const char *zpool_prop_values(int prop)
 
+    ctypedef enum vdev_name_t:
+        VDEV_NAME_PATH
+        VDEV_NAME_GUID
+        VDEV_NAME_FOLLOW_LINKS
+        VDEV_NAME_TYPE_ID
+
     IF HAVE_ZPOOL_EVENTS_NEXT:
         extern int zpool_events_next(libzfs_handle_t *, nvpair.nvlist_t **, int *, unsigned, int);
 


### PR DESCRIPTION
## Background
`zpool status` shows vdev name which middleware is not showing right now

```
  pool: testit
 state: ONLINE
config:

	NAME                                      STATE     READ WRITE CKSUM
	testit                                    ONLINE       0     0     0
	  raidz1-0                                ONLINE       0     0     0
	    eb176c2d-6fc9-4b85-bc87-9158f4e1bdb6  ONLINE       0     0     0
	    a67c61f0-6fb5-49c1-9eb0-1033021fd9f3  ONLINE       0     0     0
	    b37333f5-193e-47d2-b755-be770d5b6ace  ONLINE       0     0     0
```

## Resolution
UI team requested that we provide name of the vdev i.e `raidz1-0` and I added changes after going through https://github.com/truenas/zfs/blob/truenas/zfs-2.1-release/cmd/zpool/zpool_main.c to make sure we provide the name of the vdev in the API response.
