### PR TITLE
NAS-115408 / 13.0 / Add option to enable shares on pool import (#174) (by anodos325)

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -758,11 +758,11 @@ cdef class ZFS(object):
         return ret
 
     def run(self):
-        self.zpool_enable_datasets('pool')
+        self.zpool_enable_datasets('pool', False)
 
 
     IF HAVE_ZFS_FOREACH_MOUNTPOINT:
-        cdef int zpool_enable_datasets(self, str name) nogil:
+        cdef int zpool_enable_datasets(self, str name, int enable_shares) nogil:
             cdef libzfs.zfs_handle_t* handle
             cdef const char *c_name
             cdef libzfs.get_all_cb_t cb
@@ -787,9 +787,10 @@ cdef class ZFS(object):
             )
 
             # Share all datasets
-            libzfs.zfs_foreach_mountpoint(
-                self.handle, cb.cb_handles, cb.cb_used, ZFS.share_one_dataset, <void*>mount_results, False
-            )
+            if enable_shares:
+                libzfs.zfs_foreach_mountpoint(
+                    self.handle, cb.cb_handles, cb.cb_used, ZFS.share_one_dataset, <void*>mount_results, False
+                )
 
             # Free all handles
             for i in range(cb.cb_used):
@@ -1145,14 +1146,14 @@ cdef class ZFS(object):
 
     IF HAVE_ZFS_ENCRYPTION:
         def import_pool(
-            self, ZFSImportablePool pool, newname, opts, missing_log=False, any_host=False, load_keys=False
+            self, ZFSImportablePool pool, newname, opts, missing_log=False, any_host=False, load_keys=False, enable_shares=False
         ):
-            return self.__import_pool(pool, newname, opts, missing_log, any_host, load_keys)
+            return self.__import_pool(pool, newname, opts, missing_log, any_host, load_keys, enable_shares)
     ELSE:
-        def import_pool(self, ZFSImportablePool pool, newname, opts, missing_log=False, any_host=False):
-            return self.__import_pool(pool, newname, opts, missing_log, any_host)
+        def import_pool(self, ZFSImportablePool pool, newname, opts, missing_log=False, any_host=False, enable_shares=False):
+            return self.__import_pool(pool, newname, opts, missing_log, any_host, enable_shares)
 
-    def __import_pool(self, ZFSImportablePool pool, newname, opts, missing_log=False, any_host=False, load_keys=False):
+    def __import_pool(self, ZFSImportablePool pool, newname, opts, missing_log=False, any_host=False, load_keys=False, enable_shares=False):
         cdef const char *c_newname = newname
         cdef NVList copts = NVList(otherdict=opts)
         cdef int ret
@@ -1191,7 +1192,7 @@ cdef class ZFS(object):
                             failed_loading_keys.append(ds.name)
 
         IF HAVE_ZFS_FOREACH_MOUNTPOINT:
-            self.zpool_enable_datasets(newname)
+            self.zpool_enable_datasets(newname, enable_shares)
         ELSE:
             with nogil:
                 ret = libzfs.zpool_enable_datasets(newpool.handle, NULL, 0)


### PR DESCRIPTION
New default is to not enable them on import

Original PR: https://github.com/truenas/py-libzfs/pull/175
Jira URL: https://jira.ixsystems.com/browse/NAS-115408