### PR TITLE
NAS-116481 / 22.12 / Allow validating zfs resource names

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -301,6 +301,26 @@ cdef struct prop_iter_state:
     void *props
 
 
+def validate_dataset_name(name):
+    return validate_zfs_resource_name(name, zfs.ZFS_TYPE_FILESYSTEM | zfs.ZFS_TYPE_VOLUME)
+
+
+def validate_snapshot_name(name):
+    return validate_zfs_resource_name(name, zfs.ZFS_TYPE_SNAPSHOT)
+
+
+def validate_pool_name(name):
+    return validate_zfs_resource_name(name, zfs.ZFS_TYPE_POOL)
+
+
+cdef validate_zfs_resource_name(str name, int r_type):
+    cdef const char *c_name = name
+    cdef int ret
+    with nogil:
+        ret = libzfs.zfs_name_valid(c_name, <zfs.zfs_type_t>r_type)
+    return bool(ret)
+
+
 class DiffRecord(object):
     def __init__(self, raw):
         timestamp, cmd, typ, rest = raw.split(maxsplit=3)

--- a/pxd/libzfs.pxd
+++ b/pxd/libzfs.pxd
@@ -537,7 +537,7 @@ cdef extern from "libzfs.h" nogil:
 
     extern const char *zfs_type_to_name(zfs_type_t)
     extern void zfs_refresh_properties(zfs_handle_t *)
-    extern int zfs_name_valid(const char *, zfs_type_t)
+    extern int zfs_name_valid(const char *, zfs.zfs_type_t)
     extern zfs_handle_t *zfs_path_to_zhandle(libzfs_handle_t *, char *, zfs.zfs_type_t)
     extern int zfs_dataset_exists(libzfs_handle_t *, const char *,
         zfs_type_t)

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ except ImportError:
         config = namedtuple('config', ['CFLAGS', 'CPPFLAGS', 'LDFLAGS'])([], [], [])
 
 
-libraries=['nvpair', 'zfs', 'zfs_core', 'uutil']
+libraries = ['nvpair', 'zfs', 'zfs_core', 'uutil']
 if platform.system().lower() == 'freebsd':
     libraries.append('geom')
 


### PR DESCRIPTION
## Context

It was requested that we enhance the validation of the zfs resources we create so that we can raise appropriate validation errors before creation of the resource fails.

Utility functions are added here to validate names of pool/dataset/volumes/snapshots which can be consumed in middleware.