### PR TITLE
devel/py-libzfs: fix transfering clones from FreeBSD 12

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -244,8 +244,6 @@ class SendFlag(enum.Enum):
     REPLICATE = 1
     DOALL = 2
     FROMORIGIN = 3
-    IF HAVE_SENDFLAGS_T_DEDUP:
-        DEDUP = 3
     PROPS = 4
     DRYRUN = 5
     PARSABLE = 6
@@ -264,6 +262,8 @@ class SendFlag(enum.Enum):
         SAVED = 14
     IF HAVE_SENDFLAGS_T_PROGRESSASTITLE:
         PROGRESSASTITLE = 15
+    IF HAVE_SENDFLAGS_T_DEDUP:
+        DEDUP = 16
 
 
 class DiffRecordType(enum.Enum):


### PR DESCRIPTION
Commit ad2a851dc398fad1bf792460e3e29f645c6fcbee defined
SendFlag.FROMORIGIN and SendFlag.DEDUP to be identical, for reasons
unknown.  Notably, the values assigned to these flags are _not_ the same
values that get passed to libzfs; that translation happens later.  But
because they are identical, any time the user sets FROMORIGIN py-libzfs
will also pass DEDUP to libzfs.  That will cause a FreeBSD 13.0+
receiver to reject the stream with a messsage like
"stream has unsupported feature, feature flags = 7".  Fix this bug by
redefining SendFlag.DEDUP.

This bug does not affect a FreeBSD 13.0+ sender, since
HAVE_SENDFLAGS_T_DEDUP will be false.