### PR TITLE
NAS-116734 / 22.12 / Add error action to libzfs exception handling

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -514,10 +514,11 @@ cdef class ZFS(object):
         iter.length += 1
 
     cdef object get_error(self):
-        return ZFSException(
-            Error(libzfs.libzfs_errno(self.handle)),
-            (<bytes>libzfs.libzfs_error_description(self.handle)).decode('utf-8', 'backslashreplace')
-        )
+        description = (<bytes>libzfs.libzfs_error_description(self.handle)).decode('utf-8', 'backslashreplace')
+        error_action = (<bytes>libzfs.libzfs_error_action(self.handle)).decode('utf-8', 'backslashreplace')
+        if error_action:
+            description = f'{error_action}: {description}'
+        return ZFSException(Error(libzfs.libzfs_errno(self.handle)), description)
 
     cdef ZFSVdev make_vdev_tree(self, topology, props=None):
         cdef ZFSVdev root


### PR DESCRIPTION
## Context

It was requested that we add libzfs error action to be descriptive about the error which is being raised.
e.g
1. Without error action
```
>>> p.value = 'asd'
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "libzfs.pyx", line 1818, in libzfs.ZFSProperty.value.__set__
libzfs.ZFSException: 'snapdev' must be one of 'hidden | visible'
>>>
```

2. With error action
```
>>> p.value = 'asd'
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "libzfs.pyx", line 1827, in libzfs.ZFSProperty.value.__set__
libzfs.ZFSException: cannot set property for 'tank/extent3': 'snapdev' must be one of 'hidden | visible'
>>>
```