### PR TITLE
fix exception when lzc_sync fails

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -2881,7 +2881,7 @@ cdef class ZFSPool(object):
             with nogil:
                 ret = libzfs.lzc_sync(c_name, innvl.handle, NULL)
             if ret != 0:
-                raise self.root.get_error()
+                raise OSError(ret, os.strerror(ret))
 
     cdef NVList get_raw_config(self):
         cdef uintptr_t nvl = <uintptr_t>libzfs.zpool_get_config(self.handle, NULL)


### PR DESCRIPTION
libzfs_core functions return errnos directly, in contrast to libzfs
functions which have a more complicated mechanism, and return bespoke
error codes. py-libzfs was trying to look up a libzfs error code when
lzc_sync failed. This resulted in a ZFSException with the message
'no error'.