### PR TITLE
Fix intermittent EINVAL in ZFSPool.sync

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -3228,7 +3228,7 @@ cdef class ZFSPool(object):
     IF HAVE_LZC_SYNC:
         def sync(self, force=False):
             cdef int ret
-            cdef const char *c_name = self.name
+            cdef const char *c_name = libzfs.zpool_get_name(self.handle)
             cdef NVList innvl = NVList()
 
             innvl["force"] = force


### PR DESCRIPTION
Sometimes ZFSPool.sync doesn't pass the pool_name argument to lzc_sync
correctly.  lzc_sync sees an empty string.  Replacing the self.name
property access with the self.handle instance variable access seems to
fix the problem, though I don't understand why.

Fixes #193