### PR TITLE
NAS-118635 / 22.12 / Add wholedisk parameter when adding vdevs from pylibzfs

### DIFF
--- a/pxd/libzfs.pxd
+++ b/pxd/libzfs.pxd
@@ -35,6 +35,7 @@ IF HAVE_LIBZUTIL_HEADER:
             pass
 
         extern const pool_config_ops_t libzfs_config_ops;
+        extern boolean_t zfs_dev_is_whole_disk(const char *)
 
         IF HAVE_ZPOOL_READ_LABEL_LIBZUTIL and HAVE_ZPOOL_READ_LABEL_PARAMS == 3:
             extern int zpool_read_label(int, nvpair.nvlist_t **, int *)


### PR DESCRIPTION
Recent changes in zed cause coredump as it expects wholedisk to be present in the label during auto expand. This patch adds the wholedisk parameter during vdev addition. Also note that TrueNAS creates vdev on a partitioned disk, so it is always expected to be 0.