### PR TITLE
NAS-115780 / 22.12 / Fix improper handling of UINT64_MAX

### DIFF
--- a/converter.pxi
+++ b/converter.pxi
@@ -58,6 +58,8 @@ class ZfsConverter(object):
         if self.typ is datetime:
             return str(value.timestamp())
 
+UINT64_MAX = '18446744073709551615'
+
 
 ZPOOL_PROPERTY_CONVERTERS = {
     'name': ZfsConverter(str, readonly=True),
@@ -140,10 +142,10 @@ ZFS_PROPERTY_CONVERTERS = {
     'volmode': ZfsConverter(str),
     'volsize': ZfsConverter(int),
     'volblocksize': ZfsConverter(int),
-    'filesystem_limit': ZfsConverter(int),
-    'snapshot_limit': ZfsConverter(int),
-    'filesystem_count': ZfsConverter(int, readonly=True),
-    'snapshot_count': ZfsConverter(int, readonly=True),
+    'filesystem_limit': ZfsConverter(int, nullable=True, read_null=UINT64_MAX),
+    'snapshot_limit': ZfsConverter(int, nullable=True, read_null=UINT64_MAX),
+    'filesystem_count': ZfsConverter(int, readonly=True, nullable=True, read_null=UINT64_MAX),
+    'snapshot_count': ZfsConverter(int, readonly=True, nullable=True, read_null=UINT64_MAX),
     'redundant_metadata': ZfsConverter(str)
 }
 


### PR DESCRIPTION
## Problem

Py-libzfs was not properly handling UINT64_MAX-1
```
&gt;&gt;&gt; p = a.properties.get("snapshot_limit")
&gt;&gt;&gt; p.rawvalue
'18446744073709551615'
&gt;&gt;&gt; p.value
'none'
&gt;&gt;&gt; p.parsed
18446744073709551615 
```

## Solution

Make sure we report `None` for UINT64_MAX similar to how zfs cli does

```
    case ZFS_PROP_SNAPSHOT_COUNT:

        if (get_numeric_property(zhp, prop, src, &source, &val) != 0)
            return (-1);

        /*
         * If limit is UINT64_MAX, we translate this into 'none' (unless
         * literal is set), and indicate that it's the default value.
         * Otherwise, we print the number nicely and indicate that it's
         * set locally.
         */
```