### PR TITLE
NAS-119241 / 23.10 / Allow simple fetch of snapshot details for createtxg.

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -921,7 +921,7 @@ cdef class ZFS(object):
             simple_handle = (len(props) == 1 and ('name' in props or 'createtxg' in props)) or (len(props) == 2 and ('name' in props and 'createtxg' in props))
             simple_createtxg = simple_handle and 'createtxg' in props
             if simple_createtxg:
-                simple_props = {"createtxg" : libzfs.ZFS_PROP_CREATETXG}
+                simple_props = {"createtxg" : zfs.ZFS_PROP_CREATETXG}
             else:
                 simple_props = {}
             snap_data = {}

--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -929,6 +929,7 @@ cdef class ZFS(object):
 
         nvlist = libzfs.zfs_get_user_props(handle)
         name = libzfs.zfs_get_name(handle)
+        create_txg = libzfs.zfs_prop_get_int(handle, zfs.ZFS_PROP_CREATETXG)
 
         with gil:
 
@@ -1005,8 +1006,6 @@ cdef class ZFS(object):
         with gil:
             if not simple_handle:
                 snap_data['properties'] = properties
-
-            create_txg = libzfs.zfs_prop_get_int(handle, zfs.ZFS_PROP_CREATETXG)
 
             snap_data.update({
                 'pool': pool,

--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -896,7 +896,7 @@ cdef class ZFS(object):
 
     @staticmethod
     cdef int __snapshot_details(libzfs.zfs_handle_t *handle, void *arg) nogil:
-        cdef int prop_id, ret, simple_handle, simple_createtxg, holds, mounted
+        cdef int prop_id, ret, simple_handle, holds, mounted
         cdef char csrcstr[MAX_DATASET_NAME_LEN + 1]
         cdef char crawvalue[libzfs.ZFS_MAXPROPLEN + 1]
         cdef char cvalue[libzfs.ZFS_MAXPROPLEN + 1]
@@ -919,8 +919,7 @@ cdef class ZFS(object):
             min_txg = configuration_data['min_txg']
             max_txg = configuration_data['max_txg']
             properties = {}
-            simple_handle = (len(props) == 1 and ('name' in props or 'createtxg' in props)) or (len(props) == 2 and ('name' in props and 'createtxg' in props))
-            simple_createtxg = simple_handle and 'createtxg' in props
+            simple_handle = set(props).issubset({'name', 'createtxg'})
             snap_data = {}
 
         libzfs.zfs_iter_snapshots(handle, simple_handle, ZFS.__snapshot_details, <void*>snap_list, min_txg, max_txg)
@@ -1007,19 +1006,17 @@ cdef class ZFS(object):
             if not simple_handle:
                 snap_data['properties'] = properties
 
+            create_txg = libzfs.zfs_prop_get_int(handle, zfs.ZFS_PROP_CREATETXG)
+
             snap_data.update({
                 'pool': pool,
                 'name': name,
                 'type': DatasetType.SNAPSHOT.name,
                 'snapshot_name': name.split('@')[-1],
                 'dataset': name.split('@')[0],
-                'id': name
+                'id': name,
+                'createtxg': str(create_txg)
             })
-            if simple_createtxg:
-                create_txg = libzfs.zfs_prop_get_int(handle, zfs.ZFS_PROP_CREATETXG)
-                snap_data.update({
-                    'createtxg': str(create_txg)
-                })
 
             snap_list.append(snap_data)
 

--- a/pxd/zfs.pxd
+++ b/pxd/zfs.pxd
@@ -258,6 +258,7 @@ cdef extern from "sys/fs/zfs.h" nogil:
             ctypedef enum zfs_prop_t:
                 ZPROP_CONT = -2
                 ZPROP_INVAL	= -1
+                ZFS_PROP_CREATETXG
                 ZFS_PROP_CANMOUNT
                 ZFS_PROP_KEYSTATUS
                 ZFS_PROP_RECEIVE_RESUME_TOKEN
@@ -266,6 +267,7 @@ cdef extern from "sys/fs/zfs.h" nogil:
             ctypedef enum zfs_prop_t:
                 ZPROP_CONT = -2
                 ZPROP_INVAL	= -1
+                ZFS_PROP_CREATETXG
                 ZFS_PROP_CANMOUNT
                 ZFS_PROP_RECEIVE_RESUME_TOKEN
                 ZFS_PROP_INCONSISTENT
@@ -274,6 +276,7 @@ cdef extern from "sys/fs/zfs.h" nogil:
             ctypedef enum zfs_prop_t:
                 ZPROP_CONT = -2
                 ZPROP_INVAL	= -1
+                ZFS_PROP_CREATETXG
                 ZFS_PROP_CANMOUNT
                 ZFS_PROP_KEYSTATUS
                 ZFS_PROP_INCONSISTENT
@@ -281,6 +284,7 @@ cdef extern from "sys/fs/zfs.h" nogil:
             ctypedef enum zfs_prop_t:
                 ZPROP_CONT = -2
                 ZPROP_INVAL	= -1
+                ZFS_PROP_CREATETXG
                 ZFS_PROP_CANMOUNT
                 ZFS_PROP_INCONSISTENT
     


### PR DESCRIPTION
When iterating over snapshots, pass simple to `zfs_iter_snapshots` if the requested props are either 'name' or 'createtxg', or both.