### PR TITLE
NAS-119414 / 23.10 / get error from correct handle

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -3529,7 +3529,7 @@ cdef class ZFSResource(ZFSObject):
             with nogil:
                 ret = libzfs.zfs_userspace(self.handle, prop, ZFSResource._userspace_cb, <void*>result)
             if ret:
-                raise self.get_error()
+                raise self.root.get_error()
             results[quota_prop] = result
         return results
 


### PR DESCRIPTION
We should be getting error from libzfs handle and not dataset handle.
```
File "libzfs.pyx", line 461, in libzfs.ZFS.__exit__
  File "/usr/local/lib/python3.9/dist-packages/middlewared/plugins/zfs.py", line 743, in get_quota
    quotas = resource.userspace(quota_props)
  File "libzfs.pyx", line 3523, in libzfs.ZFSResource.userspace
AttributeError: 'libzfs.ZFSDataset' object has no attribute 'get_error'
```