### PR TITLE
NAS-120446 / 22.12.2 / default to "py-libzfs:" history_prefix (by yocalebo)

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -423,7 +423,7 @@ cdef class ZFS(object):
     cdef char *history_prefix
     proptypes = {}
 
-    def __cinit__(self, history=True, history_prefix='', mnttab_cache=True):
+    def __cinit__(self, history=True, history_prefix='py-libzfs:', mnttab_cache=True):
         cdef zfs.zfs_type_t c_type
         cdef prop_iter_state iter
         self.mnttab_cache_enable=mnttab_cache


### PR DESCRIPTION
TrueNAS being the main consumer of this library has shown that we often have users do things "by hand" (aka via the cli) and while that isn't necessarily a problem, it does make it hard to track down certain edge-case failure conditions. This changes it so that the `history_prefix` argument to `ZFS` class defaults to `py-libzfs:` instead of an empty string. This will allow us to more easily identify the "source" of zfs/zpool operations.

Here is a small excerpt of what zpool history looks like after changes:
```
2023-02-27.07:15:25 py-libzfs: zpool create -o feature@lz4_compress=enabled -o altroot=/mnt -o cachefile=/data/zfs/zpool.cache -o ... -O mountpoint=/cargo cargo /dev/disk/by-partuuid/b15b34df-e9ba-4c05-961b-62a090a50182
2023-02-27.07:15:26 py-libzfs: zfs inherit  cargo
2023-02-27.07:15:26 py-libzfs: zfs mount cargo 

Original PR: https://github.com/truenas/py-libzfs/pull/228
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120446