### PR TITLE
NAS-121926 / 23.10 / Add draid support

### DIFF
--- a/pxd/zfs.pxd
+++ b/pxd/zfs.pxd
@@ -61,6 +61,10 @@ cdef extern from "sys/fs/zfs.h" nogil:
     const char* ZPOOL_CONFIG_DDT_OBJ_STATS
     const char* ZPOOL_CONFIG_LOAD_INFO
     const char* ZPOOL_CONFIG_UNSUP_FEAT
+    const char* ZPOOL_CONFIG_DRAID_NDATA
+    const char* ZPOOL_CONFIG_DRAID_NSPARES
+    const char* ZPOOL_CONFIG_DRAID_NGROUPS
+    const char* VDEV_TYPE_DRAID
 
     IF HAVE_ZPOOL_CONFIG_ALLOCATION_BIAS:
         const char* ZPOOL_CONFIG_ALLOCATION_BIAS
@@ -389,6 +393,11 @@ cdef extern from "sys/fs/zfs.h" nogil:
         ZPOOL_EXTREME_REWIND
         ZPOOL_REWIND_MASK
         ZPOOL_REWIND_POLICIES
+
+    enum:
+        VDEV_DRAID_MAXPARITY
+        VDEV_DRAID_MIN_CHILDREN
+        VDEV_DRAID_MAX_CHILDREN
 
     ctypedef struct zpool_rewind_policy_t:
         uint32_t	zrp_request


### PR DESCRIPTION
## Context

DRAID type vdev support has been added to py-libzfs so middleware can consume the changes. Validation logic has been separated so it can be consumed separately by middleware when we want to allow other configuration options for draid type vdevs and raised as validation errors whenever the provided values are invalid.