### PR TITLE
NAS-123279 / 24.04 / Ignore errors while setting sharesmb/sharenfs properties

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -3597,6 +3597,7 @@ cdef class ZFSResource(ZFSObject):
 
     def update_properties(self, all_properties):
         cdef NVList props = NVList()
+        cdef NVList try_props = NVList()
         cdef int ret
         invalid_values = []
         for prop_name, prop_details in all_properties.items():
@@ -3605,9 +3606,20 @@ cdef class ZFSResource(ZFSObject):
                 cur_prop.inherit(recursive=prop_details.get('recursive', False))
             else:
                 if 'value' in prop_details:
-                    props[prop_name] = prop_details['value']
+                    if self.properties.get(prop_name).value != prop_details.get('value') or \
+                        self.properties.get(prop_name).source.name != prop_details.get('source'):
+                        if prop_name == 'sharesmb' or prop_name == 'sharenfs':
+                            try_props[prop_name] = prop_details['value']
+                        else:
+                            props[prop_name] = prop_details['value']
                 elif 'parsed' in prop_details:
-                    props[prop_name] = serialize_zfs_prop(prop_name, prop_details['parsed'])
+                    prop = serialize_zfs_prop(prop_name, prop_details['parsed'])
+                    if self.properties.get(prop_name).value != prop or \
+                        self.properties.get(prop_name).source.name != prop_details.get('source'):
+                        if prop_name == 'sharesmb' or prop_name == 'sharenfs':
+                            try_props[prop_name] = prop
+                        else:
+                            props[prop_name] = prop
                 else:
                     invalid_values.append(prop_name)
 
@@ -3619,6 +3631,10 @@ cdef class ZFSResource(ZFSObject):
 
         if ret != 0:
             raise self.root.get_error()
+
+        if len(try_props.keys()) > 0:
+            with nogil:
+                libzfs.zfs_prop_set_list(self.handle, try_props.handle)
 
     @staticmethod
     cdef int _userspace_cb(void *data, const char *domain, uint32_t rid, uint64_t space) nogil:


### PR DESCRIPTION
From UI, pool import fails for users that have sharesmb and/or sharenfs properties set for dataset/s. This failure occurs because ZFSDatasetService fails to update properties of the new imported dataset/s.

ZFS provided sharing mechanism is not compatible with how it is implemented in TrueNAS, so when these properties are set, failure occurs because sharing is not successful.

These failures while updating the properties should be ignored, and pool import should be allowed to continue, with sharesmb and/or sharenfs set.