### PR TITLE
Revert "Ignore errors while setting sharesmb/sharenfs properties"

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -3597,7 +3597,6 @@ cdef class ZFSResource(ZFSObject):
 
     def update_properties(self, all_properties):
         cdef NVList props = NVList()
-        cdef NVList try_props = NVList()
         cdef int ret
         invalid_values = []
         for prop_name, prop_details in all_properties.items():
@@ -3606,20 +3605,9 @@ cdef class ZFSResource(ZFSObject):
                 cur_prop.inherit(recursive=prop_details.get('recursive', False))
             else:
                 if 'value' in prop_details:
-                    if self.properties.get(prop_name).value != prop_details.get('value') or \
-                        self.properties.get(prop_name).source.name != prop_details.get('source'):
-                        if prop_name == 'sharesmb' or prop_name == 'sharenfs':
-                            try_props[prop_name] = prop_details['value']
-                        else:
-                            props[prop_name] = prop_details['value']
+                    props[prop_name] = prop_details['value']
                 elif 'parsed' in prop_details:
-                    prop = serialize_zfs_prop(prop_name, prop_details['parsed'])
-                    if self.properties.get(prop_name).value != prop or \
-                        self.properties.get(prop_name).source.name != prop_details.get('source'):
-                        if prop_name == 'sharesmb' or prop_name == 'sharenfs':
-                            try_props[prop_name] = prop
-                        else:
-                            props[prop_name] = prop
+                    props[prop_name] = serialize_zfs_prop(prop_name, prop_details['parsed'])
                 else:
                     invalid_values.append(prop_name)
 
@@ -3631,10 +3619,6 @@ cdef class ZFSResource(ZFSObject):
 
         if ret != 0:
             raise self.root.get_error()
-
-        if len(try_props.keys()) > 0:
-            with nogil:
-                libzfs.zfs_prop_set_list(self.handle, try_props.handle)
 
     @staticmethod
     cdef int _userspace_cb(void *data, const char *domain, uint32_t rid, uint64_t space) nogil:


### PR DESCRIPTION
This reverts commit 0c707f71811ec66d5bbdffdaba3ec70de407a655.