### PR TITLE
NAS-124238 / 23.10 / fix mount() function to work on openzfs 2.2 (by yocalebo)

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -4070,13 +4070,14 @@ cdef class ZFSDataset(ZFSResource):
     def mount(self):
         cdef int ret
 
-        with nogil:
-            ret = libzfs.zfs_mount(self.handle, NULL, 0)
+        if self.properties['mounted'].value == 'no':
+            with nogil:
+                ret = libzfs.zfs_mount(self.handle, NULL, 0)
 
-        if ret != 0:
-            raise self.root.get_error()
+            if ret != 0:
+                raise self.root.get_error()
 
-        self.root.write_history('zfs mount', self.name)
+            self.root.write_history('zfs mount', self.name)
 
     IF HAVE_ZFS_ENCRYPTION:
         def mount_recursive(self, ignore_errors=False, skip_unloaded_keys=True):


### PR DESCRIPTION
zfs_mount() behavior changed recently in openzfs. EBUSY is returned when trying to explicitly mount a dataset when it's already mounted. This works around the issue by first checking the `mounted` dataset property and seeing it if reports 'no'. If it does, only then will we call zfs_mount().

Note: not using zfs_is_mounted() since it's considered to be racy (iterates /proc/self/mounts on linux).

Original PR: https://github.com/truenas/py-libzfs/pull/239
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124238