### PR TITLE
NAS-124286 / 23.10 / fix KeyError crash in mount() (by yocalebo)

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -4070,14 +4070,20 @@ cdef class ZFSDataset(ZFSResource):
     def mount(self):
         cdef int ret
 
-        if self.properties['mounted'].value == 'no':
-            with nogil:
-                ret = libzfs.zfs_mount(self.handle, NULL, 0)
+        try:
+            mounted = self.properties['mounted']
+        except KeyError:
+            # zvols don't have a mounted property
+            return
+        else:
+            if mounted.value == 'no':
+                with nogil:
+                    ret = libzfs.zfs_mount(self.handle, NULL, 0)
 
-            if ret != 0:
-                raise self.root.get_error()
+                if ret != 0:
+                    raise self.root.get_error()
 
-            self.root.write_history('zfs mount', self.name)
+                self.root.write_history('zfs mount', self.name)
 
     IF HAVE_ZFS_ENCRYPTION:
         def mount_recursive(self, ignore_errors=False, skip_unloaded_keys=True):


### PR DESCRIPTION
A recent commit was merged (https://github.com/truenas/py-libzfs/pull/239) to work-around an upstream libzfs api behavioral change. However, it introduced a regression by not taking into account that this function can be called against a zvol. Obviously, a zvol doesn't have a `mounted` property so this change ensures that we don't crash with a KeyError.

Original PR: https://github.com/truenas/py-libzfs/pull/241
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124286