### PR TITLE
NAS-124390 / 24.04 / properly catch errors in zfs_prop_set_list()

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -3617,7 +3617,12 @@ cdef class ZFSResource(ZFSObject):
         with nogil:
             ret = libzfs.zfs_prop_set_list(self.handle, props.handle)
 
-        if ret != 0:
+        if ret != 0 or self.root.errno != 0:
+            # setting the propert(y/ies) failed or
+            # the propert(y/ies) was/were changed successfully
+            # but the extended behavior that comes after failed
+            # (i.e. sharenfs=on will update files in exports/conf.d
+            #   which can fail for a myriad of reasons)
             raise self.root.get_error()
 
     @staticmethod


### PR DESCRIPTION
With the behavioral changes introduced in https://github.com/truenas/zfs/commit/22da5ae59fbf8902f4897c2d417f5673591cc8e7, it was intended that `zfs_prop_set_list` return 0 (success) when, for example, `sharenfs=on` but updating files in `exports/conf.d` failed.

This means that we can't just check for the return value of that function, we now need to check for the returned value as well as the errno being set on the handle.