### PR TITLE
NAS-130336 / 24.10 / Update total_secs_left to match upstream ZFS 

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -2711,10 +2711,10 @@ cdef class ZPoolScrub(object):
             if self.state != ScanState.SCANNING:
                 return
 
-            total = self.bytes_to_scan
+            total = self.bytes_to_scan - self.stats.pss_skipped
             issued = self.bytes_issued
             elapsed = ((int(time.time()) - self.stats.pss_pass_start) - self.stats.pss_pass_scrub_spent_paused) or 1
-            pass_issued = self.stats.pss_pass_issued or 1
+            pass_issued = self.stats.pss_pass_issued
             issue_rate = pass_issued / elapsed
             return int((total - issued) / issue_rate)
 

--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -2714,7 +2714,7 @@ cdef class ZPoolScrub(object):
             total = self.bytes_to_scan - self.stats.pss_skipped
             issued = self.bytes_issued
             elapsed = ((int(time.time()) - self.stats.pss_pass_start) - self.stats.pss_pass_scrub_spent_paused) or 1
-            pass_issued = self.stats.pss_pass_issued
+            pass_issued = self.stats.pss_pass_issued or 1
             issue_rate = pass_issued / elapsed
             return int((total - issued) / issue_rate)
 


### PR DESCRIPTION
I've updated the algorithm that determines the number of seconds left in a scrub to match what we have for `zpool status`.
I've only been able to test with a 30~ gig scrub, ideally testing on a much bigger set of data would be better