### PR TITLE
NAS-131711 / 25.04 / Change snapdir type to str

### DIFF
--- a/converter.pxi
+++ b/converter.pxi
@@ -110,7 +110,7 @@ ZFS_PROPERTY_CONVERTERS = {
     'setuid': ZfsConverter(bool),
     'readonly': ZfsConverter(bool),
     'jailed': ZfsConverter(bool),
-    'snapdir': ZfsConverter(bool, off='hidden', on='visible'),
+    'snapdir': ZfsConverter(str),
     'aclmode': ZfsConverter(str),
     'aclinherit': ZfsConverter(str),
     'canmount': ZfsConverter(bool),


### PR DESCRIPTION
The commit https://github.com/openzfs/zfs/commit/d34d4f9 added a new `disabled` value to the `snapdir` property. Since it can now return three possible strings, update its type to `str`, similar to other properties like `compression` and `acltype`. Additionally, the parsing of the `snapdir` property in py-libzfs was already broken before the zfs-2.3 update. It was supposed to return `True` when set to `hidden` and `False` when set to `visible`, but instead, it returned `None` for both states.

Scale Build: http://jenkins.eng.ixsystems.net:8080/job/master/job/custom/607/
API Test Run: http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/1280/