### PR TITLE
NAS-132126 / 24.10.0.1 / Add missing error code from libzfs (by usaleem-ix) (by bugclerk)

### DIFF
--- a/pxd/libzfs.pxd
+++ b/pxd/libzfs.pxd
@@ -178,6 +178,7 @@ cdef extern from "libzfs.h" nogil:
         EZFS_RESUME_EXISTS
         EZFS_SHAREFAILED
         EZFS_RAIDZ_EXPAND_IN_PROGRESS
+        EZFS_ASHIFT_MISMATCH
         EZFS_UNKNOWN
 
     IF HAVE_ZFS_ENCRYPTION:


### PR DESCRIPTION
`EZFS_ASHIFT_MISMATCH` was added to `libzfs.h`, but since it was not present in `py-libzfs`, the error codes are out of sync. This commit fixes this issue.

Original PR: https://github.com/truenas/py-libzfs/pull/289
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132126

Original PR: https://github.com/truenas/py-libzfs/pull/290
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132126