### PR TITLE
NAS-131249 / 25.04 / Add dedup prefetch/prune support in py-libzfs

### DIFF
--- a/converter.pxi
+++ b/converter.pxi
@@ -77,6 +77,8 @@ ZPOOL_PROPERTY_CONVERTERS = {
     'failmode': ZfsConverter(str, nullable=True),
     'listsnapshots': ZfsConverter(bool, nullable=True),
     'autoexpand': ZfsConverter(bool, nullable=True),
+    'dedup_table_size': ZfsConverter(int, readonly=True, nullable=True),
+    'dedupcached': ZfsConverter(int, readonly=True, nullable=True),
     'dedupditto': ZfsConverter(int, readonly=True, nullable=True),
     'dedupratio': ZfsConverter(str, readonly=True, nullable=True),
     'free': ZfsConverter(int, readonly=True, nullable=True),

--- a/pxd/libzfs.pxd
+++ b/pxd/libzfs.pxd
@@ -629,6 +629,9 @@ cdef extern from "libzfs.h" nogil:
     extern int zmount(const char *, const char *, int, char *, char *, int, char *,
         int)
 
+    extern int zpool_prefetch(zpool_handle_t *, zfs.zpool_prefetch_type_t);
+    extern int zpool_ddt_prune(zpool_handle_t *, zfs.zpool_ddt_prune_unit_t, uint64_t)
+
     IF HAVE_ZFS_FOREACH_MOUNTPOINT:
         extern void zfs_foreach_mountpoint(
             libzfs_handle_t *, zfs_handle_t **, size_t, zfs_iter_f, void*, boolean_t

--- a/pxd/zfs.pxd
+++ b/pxd/zfs.pxd
@@ -115,6 +115,15 @@ cdef extern from "sys/fs/zfs.h" nogil:
             ZPOOL_WAIT_TRIM,
             ZPOOL_WAIT_NUM_ACTIVITIES
 
+    ctypedef enum zpool_prefetch_type_t:
+        ZPOOL_PREFETCH_NONE
+        ZPOOL_PREFETCH_DDT
+
+    ctypedef enum zpool_ddt_prune_unit_t:
+        ZPOOL_DDT_PRUNE_NONE
+        ZPOOL_DDT_PRUNE_AGE
+        ZPOOL_DDT_PRUNE_PERCENTAGE
+
     enum:
         ZIO_TYPES
         ZFS_NUM_USERQUOTA_PROPS


### PR DESCRIPTION
## Context

It has been requested that we add ddt prefetch/prune support in middleware. Relevant usages have been updated in py-libzfs so the support for it can be exposed in middleware.