### PR TITLE
NAS-132988 / 25.04 / Do not retrieve hidden zpool properties

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -3127,7 +3127,7 @@ cdef class ZFSPool(object):
             result = {}
 
             with nogil:
-                libzfs.zprop_iter(self.__iterate_props, <void*>proptypes, True, True, zfs.ZFS_TYPE_POOL)
+                libzfs.zprop_iter(self.__iterate_props, <void*>proptypes, False, True, zfs.ZFS_TYPE_POOL)
 
             for x in proptypes:
                 prop = ZPoolProperty.__new__(ZPoolProperty)


### PR DESCRIPTION
`zprop_iter` provides an interface to iterate over all available zpool properties. To iterate over hidden zpool properties, `show_all` parameter should be set to true.

Recently, `dedupcached` property was added as part of fast dedup support in ZFS. This property is quite expensive since it needs to calculate the total size of dedup table loaded into the ARC.

This commit updates the `show_all` parameter passed to `zprop_iter`, and sets it to `False`, since we don't want to retrieve the `dedupcached` property. All other hidden zpool properties will not be retrieved either as part of `zprop_iter`. These properties include `name`, `tname`, `maxblocksize`, `maxdnodesize`, `dedupditto` and `dedupcached`.