### PR TITLE
NAS-137885 / 26.04 / Explicit set ashift for non-leaf vdevs

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -674,8 +674,10 @@ cdef class ZFS(object):
             cdef char vpath[zfs.MAXPATHLEN + 1]
             cdef boolean_t whole_disk
             IF IS_OPENZFS:
+                if ashift_value:
+                    (<ZFSVdev>vdev).set_ashift(ashift_value)
                 # Each leaf vdev is supposed to have the wholedisk
-                # and ashift properties in its nvlist
+                # property in its nvlist
                 if vdev.type != 'disk':
                     for child in vdev.children:
                         add_properties_to_vdev(child)
@@ -684,8 +686,6 @@ cdef class ZFS(object):
                     with nogil:
                         whole_disk = zfs_dev_is_whole_disk(vpath)
                     (<ZFSVdev>vdev).set_whole_disk(whole_disk)
-                    if ashift_value:
-                        (<ZFSVdev>vdev).set_ashift(ashift_value)
             return vdev
 
         root = <ZFSVdev>add_properties_to_vdev(root)


### PR DESCRIPTION
Before this change ashift property was applied only to a leaf vdevs.  As result, it worked only as a minimal value for parent vdevs, since bigger physical_ashift value reported by any child could be used instead when deciding parent's ashift, as if the ashift property was never set.

This change explicitly passes ZPOOL_CONFIG_ASHIFT to all vdevs, allowing override for parents only if the passed value is below logical_ashift and so unacceptable.

This is a py-libzfs equivalent of https://github.com/truenas/zfs/pull/314/commits/f6fe2767d611a8af992c5ef30ed09d7ff718227f .