### PR TITLE
NAS-138043 / 26.04 / Allow creating special vdev with draid topology

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -712,6 +712,10 @@ cdef class ZFS(object):
             children = len(topology['draid'])
             for draid in topology['draid']:
                 vdev = <ZFSVdev>draid['disk']
+                IF HAVE_ZPOOL_CONFIG_ALLOCATION_BIAS:
+                    if draid['parameters'].pop('special_vdev', False):
+                        vdev.nvlist[zfs.ZPOOL_CONFIG_IS_LOG] = False
+                        vdev.nvlist[zfs.ZPOOL_CONFIG_ALLOCATION_BIAS] = zfs.VDEV_ALLOC_BIAS_SPECIAL
                 update_draid_config(vdev.nvlist, **draid['parameters'])
                 root.add_child_vdev((<ZFSVdev>add_properties_to_vdev(vdev)))
 


### PR DESCRIPTION
## Context

With zfs 2.4, we want to allow creating special vdevs with draid topology, however currently the draid topology was treated as a data vdev which in this case would not allow creating special vdevs with that configuration. We now optionally creating that as a special vdev if specified by the consumer.