### PR TITLE
Add deprecation notice to pylibzfs repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 py-libzfs
 ======
 
+> [!WARNING]
+> **Deprecation Notice:** This repository is deprecated. TrueNAS is transitioning its Python ZFS bindings to
+> [github.com/truenas/truenas_pylibzfs](https://github.com/truenas/truenas_pylibzfs). Note that the new
+> repository is Linux-only and targets the ZFS version distributed with TrueNAS. This repository will no
+> longer receive updates.
+
 **Python bindings for libzfs**
 
 py-libzfs is a fairly straight-forward set of Python bindings for libzfs for ZFS on Linux and FreeBSD.


### PR DESCRIPTION
TrueNAS has already largely transitioned away from using this python library. We still consume in a few of our non-master branches, but this dependency will be removed entirely in a future release. The formal deprecation notice is to provide external library consumers notice that we are no longer accepting changes to the repository and that at a future time as determined by the TrueNAS engineering team this repository will be formally archived.